### PR TITLE
Wire up inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-azure-servicebus-explorer
 
-To install and start (tested on Mac node v12.16.1 and v13.12.0):
+To install and start (tested on Mac node v12.16.1 and v14.3.0):
 `npm run install-app && npm start`
 
 backend/topic-peek.js

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,8 +31,9 @@ SUBSCRIPTION_NAME=${envVars.sub}`;
   ctx.body = ctx.request.body;
 }
 
-async function kill() {
-  process.exit();
+async function kill(ctx) {
+  setTimeout(process.exit);
+  ctx.body = { status: 200 };
 }
 
 app

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -7,7 +7,6 @@
 <input type="text" placeholder="Topic Name" [(ngModel)]="env.topic" />
 <input type="text" placeholder="Subscription Name" [(ngModel)]="env.sub" />
 <button (click)="updateConnection()">Update Service Bus Connection</button>
-<button (click)="restartServer()">Restart Server</button>
 <h2>Azure Service Bus Topic Messages</h2>
 <div *ngIf="!messages.length">Loading...</div>
 <ul *ngFor="let message of messages">

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,3 +1,4 @@
+<h1>{{ title }}</h1>
 <input type="text" placeholder="Connection String" />
 <input type="text" placeholder="Topic Name" />
 <input type="text" placeholder="Subscription Name" />

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,7 +1,15 @@
 <h1>{{ title }}</h1>
-<input type="text" placeholder="Connection String" />
-<input type="text" placeholder="Topic Name" />
-<input type="text" placeholder="Subscription Name" />
+<input
+  type="text"
+  placeholder="Connection String"
+  [(ngModel)]="connectionString"
+/>
+<input type="text" placeholder="Topic Name" [(ngModel)]="topicName" />
+<input
+  type="text"
+  placeholder="Subscription Name"
+  [(ngModel)]="subscriptionName"
+/>
 <button (click)="updateConnection()">Update Service Bus Connection</button>
 <button (click)="restartServer()">Restart Server</button>
 <h2>Azure Service Bus Topic Messages</h2>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,8 +2,8 @@
 <input type="text" placeholder="Connection String" />
 <input type="text" placeholder="Topic Name" />
 <input type="text" placeholder="Subscription Name" />
-<button>Update Service Bus Connection</button>
-<button>Restart Server</button>
+<button (click)="updateConnection()">Update Service Bus Connection</button>
+<button (click)="restartServer()">Restart Server</button>
 <h2>Azure Service Bus Topic Messages</h2>
 <div *ngIf="!messages.length">Loading...</div>
 <ul *ngFor="let msg of messages">

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -10,7 +10,7 @@
 <h2>Azure Service Bus Topic Messages</h2>
 <div *ngIf="isLoadingMessages">Loading...</div>
 <div *ngIf="!isLoadingMessages && !messages.length">No messages.</div>
-<ul *ngFor="let message of messages">
-  <li>{{ message }}</li>
-</ul>
+<ol>
+  <li *ngFor="let message of messages">{{ message }}</li>
+</ol>
 <!-- <router-outlet></router-outlet> -->

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -8,7 +8,8 @@
 <input type="text" placeholder="Subscription Name" [(ngModel)]="env.sub" />
 <button (click)="updateConnection()">Update Service Bus Connection</button>
 <h2>Azure Service Bus Topic Messages</h2>
-<div *ngIf="!messages.length">Loading...</div>
+<div *ngIf="isLoadingMessages">Loading...</div>
+<div *ngIf="!isLoadingMessages && !messages.length">No messages.</div>
 <ul *ngFor="let message of messages">
   <li>{{ message }}</li>
 </ul>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,14 +2,10 @@
 <input
   type="text"
   placeholder="Connection String"
-  [(ngModel)]="connectionString"
+  [(ngModel)]="env.connString"
 />
-<input type="text" placeholder="Topic Name" [(ngModel)]="topicName" />
-<input
-  type="text"
-  placeholder="Subscription Name"
-  [(ngModel)]="subscriptionName"
-/>
+<input type="text" placeholder="Topic Name" [(ngModel)]="env.topic" />
+<input type="text" placeholder="Subscription Name" [(ngModel)]="env.sub" />
 <button (click)="updateConnection()">Update Service Bus Connection</button>
 <button (click)="restartServer()">Restart Server</button>
 <h2>Azure Service Bus Topic Messages</h2>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -5,8 +5,8 @@
 <button>Update Service Bus Connection</button>
 <button>Restart Server</button>
 <h2>Azure Service Bus Topic Messages</h2>
-<div *ngIf="!messages">Loading...</div>
+<div *ngIf="!messages.length">Loading...</div>
 <ul *ngFor="let msg of messages">
-  <li>{{ msg[0].body }}</li>
+  <li>{{ msg }}</li>
 </ul>
 <!-- <router-outlet></router-outlet> -->

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -6,7 +6,7 @@
 <button (click)="restartServer()">Restart Server</button>
 <h2>Azure Service Bus Topic Messages</h2>
 <div *ngIf="!messages.length">Loading...</div>
-<ul *ngFor="let msg of messages">
-  <li>{{ msg }}</li>
+<ul *ngFor="let message of messages">
+  <li>{{ message }}</li>
 </ul>
 <!-- <router-outlet></router-outlet> -->

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -17,3 +17,15 @@ button {
   background-color: #1976d2;
   color: white;
 }
+
+li {
+  margin: 10px 0;
+
+  &:first-child {
+    margin-top: 0;
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -13,6 +13,11 @@ h2 {
   margin: 8px 0;
 }
 
+input {
+  width: 100%;
+  margin-bottom: 5px;
+}
+
 button {
   background-color: #1976d2;
   color: white;

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -8,6 +8,7 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+h1,
 h2 {
   margin: 8px 0;
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -8,18 +8,17 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   public title = 'node-azure-servicebus-explorer-fe';
-
   public messages = null;
 
   private apiUrl = 'http://localhost:3000';
-
-  private getTopics() {
-    return this.http.get(this.apiUrl + '/peek');
-  }
 
   constructor(private http: HttpClient) {
     this.getTopics().subscribe((msgs) => {
       this.messages = msgs;
     });
+  }
+
+  private getTopics() {
+    return this.http.get(this.apiUrl + '/peek');
   }
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { processMessages } from './functions';
-import { API, getApi } from './structs';
+import { getApi, processMessages } from './functions';
+import { API } from './structs';
 import { emptyPostRequestBody } from './structs/mocks';
 
 @Component({

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -36,10 +36,6 @@ export class AppComponent implements OnDestroy, OnInit {
     );
   };
 
-  public restartServer = (): void => {
-    console.log('restartServer');
-  };
-
   private handleMessages = (messages: any[] = []): void => {
     this.messages = processMessages(messages);
   };

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -9,7 +9,7 @@ import { Observable, Subscription } from 'rxjs';
 })
 export class AppComponent implements OnDestroy, OnInit {
   public title = 'node-azure-servicebus-explorer-fe';
-  public messages = null;
+  public messages: string[] = [];
 
   private subscriptions = new Subscription();
   private apiUrl = 'http://localhost:3000';
@@ -28,6 +28,6 @@ export class AppComponent implements OnDestroy, OnInit {
     this.http.get(`${this.apiUrl}/peek`);
 
   private handleMessages = (msgs: any[] = []): void => {
-    this.messages = msgs;
+    this.messages = msgs?.flatMap((x: any): string => x?.[0]?.body ?? []) ?? [];
   };
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -24,6 +24,14 @@ export class AppComponent implements OnDestroy, OnInit {
     this.subscriptions.unsubscribe();
   }
 
+  public updateConnection = (): void => {
+    console.log('updateConnection');
+  };
+
+  public restartServer = (): void => {
+    console.log('restartServer');
+  };
+
   private getTopics = (): Observable<any> =>
     this.http.get(`${this.apiUrl}/peek`);
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,18 +1,20 @@
 import { HttpClient } from '@angular/common/http';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   public title = 'node-azure-servicebus-explorer-fe';
   public messages = null;
 
   private apiUrl = 'http://localhost:3000';
 
-  constructor(private http: HttpClient) {
+  constructor(private http: HttpClient) {}
+
+  public ngOnInit(): void {
     this.getTopics().subscribe((msgs) => {
       this.messages = msgs;
     });

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -24,9 +24,8 @@ export class AppComponent implements OnDestroy, OnInit {
     this.subscriptions.unsubscribe();
   }
 
-  private getTopics() {
-    return this.http.get(this.apiUrl + '/peek');
-  }
+  private getTopics = (): Observable<any> =>
+    this.http.get(`${this.apiUrl}/peek`);
 
   private handleMessages = (msgs: any[] = []): void => {
     this.messages = msgs;

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -45,6 +45,7 @@ export class AppComponent implements OnDestroy, OnInit {
   };
 
   private fetchMessages = (): void => {
+    this.messages = [];
     this.isLoadingMessages = true;
     const subscription = this.subscriptions.add(
       this.api.getTopics().subscribe((messages): void => {
@@ -69,6 +70,6 @@ export class AppComponent implements OnDestroy, OnInit {
   };
 
   private handlePostResponse = (response: any): void => {
-    console.log('POST response', response);
+    this.fetchMessages();
   };
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { getApi, processMessages } from './functions';
+import { getApi, isEnvValid, processMessages } from './functions';
 import { API } from './structs';
 import { emptyPostRequestBody } from './structs/mocks';
 
@@ -33,6 +33,10 @@ export class AppComponent implements OnDestroy, OnInit {
   }
 
   public updateConnection = (): void => {
+    if (!isEnvValid(this.env)) {
+      alert('Connection info is incomplete or invalid.');
+      return;
+    }
     this.subscriptions.add(
       this.api.postEnv(this.env).subscribe(this.handlePostResponse)
     );

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -7,13 +7,13 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
-  title = 'node-azure-servicebus-explorer-fe';
+  public title = 'node-azure-servicebus-explorer-fe';
 
-  messages = null;
+  public messages = null;
 
-  apiUrl = 'http://localhost:3000';
+  private apiUrl = 'http://localhost:3000';
 
-  getTopics() {
+  private getTopics() {
     return this.http.get(this.apiUrl + '/peek');
   }
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -13,6 +13,7 @@ import { emptyPostRequestBody } from './structs/mocks';
 export class AppComponent implements OnDestroy, OnInit {
   public title = 'node-azure-servicebus-explorer-fe';
   public env = emptyPostRequestBody;
+  public isLoadingMessages = false;
   public messages: string[] = [];
 
   private subscriptions = new Subscription();
@@ -23,6 +24,7 @@ export class AppComponent implements OnDestroy, OnInit {
   }
 
   public ngOnInit(): void {
+    this.isLoadingMessages = true;
     this.subscriptions.add(this.api.getTopics().subscribe(this.handleMessages));
   }
 
@@ -38,6 +40,7 @@ export class AppComponent implements OnDestroy, OnInit {
 
   private handleMessages = (messages: any[] = []): void => {
     this.messages = processMessages(messages);
+    this.isLoadingMessages = false;
   };
 
   private handlePostResponse = (res: any): void => {

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -36,7 +36,7 @@ export class AppComponent implements OnDestroy, OnInit {
   private getTopics = (): Observable<any> =>
     this.http.get(`${this.apiUrl}/peek`);
 
-  private handleMessages = (msgs: any[] = []): void => {
-    this.messages = processMessages(msgs);
+  private handleMessages = (messages: any[] = []): void => {
+    this.messages = processMessages(messages);
   };
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
+import { processMessages } from './functions';
 
 @Component({
   selector: 'app-root',
@@ -36,6 +37,6 @@ export class AppComponent implements OnDestroy, OnInit {
     this.http.get(`${this.apiUrl}/peek`);
 
   private handleMessages = (msgs: any[] = []): void => {
-    this.messages = msgs?.flatMap((x: any): string => x?.[0]?.body ?? []) ?? [];
+    this.messages = processMessages(msgs);
   };
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -10,6 +10,9 @@ import { processMessages } from './functions';
 })
 export class AppComponent implements OnDestroy, OnInit {
   public title = 'node-azure-servicebus-explorer-fe';
+  public connectionString = '';
+  public topicName = '';
+  public subscriptionName = '';
   public messages: string[] = [];
 
   private subscriptions = new Subscription();
@@ -26,7 +29,7 @@ export class AppComponent implements OnDestroy, OnInit {
   }
 
   public updateConnection = (): void => {
-    console.log('updateConnection');
+    this.postEnv().subscribe((res) => console.log('res', res));
   };
 
   public restartServer = (): void => {
@@ -35,6 +38,16 @@ export class AppComponent implements OnDestroy, OnInit {
 
   private getTopics = (): Observable<any> =>
     this.http.get(`${this.apiUrl}/peek`);
+
+  private postEnv = (): Observable<any> => {
+    const {
+      connectionString: connString,
+      topicName: topic,
+      subscriptionName: sub,
+    } = this;
+    const body: any = { connString, topic, sub };
+    return this.http.post(`${this.apiUrl}/set-env`, body);
+  };
 
   private handleMessages = (messages: any[] = []): void => {
     this.messages = processMessages(messages);

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { processMessages } from './functions';
-import { api } from './structs';
+import { API, getApi } from './structs';
 import { emptyPostRequestBody } from './structs/mocks';
 
 @Component({
@@ -16,11 +16,14 @@ export class AppComponent implements OnDestroy, OnInit {
   public messages: string[] = [];
 
   private subscriptions = new Subscription();
+  private api: API;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) {
+    this.api = getApi(this.http);
+  }
 
   public ngOnInit(): void {
-    this.subscriptions.add(this.getTopics().subscribe(this.handleMessages));
+    this.subscriptions.add(this.api.getTopics().subscribe(this.handleMessages));
   }
 
   public ngOnDestroy(): void {
@@ -28,18 +31,14 @@ export class AppComponent implements OnDestroy, OnInit {
   }
 
   public updateConnection = (): void => {
-    this.subscriptions.add(this.postEnv().subscribe(this.handlePostResponse));
+    this.subscriptions.add(
+      this.api.postEnv(this.env).subscribe(this.handlePostResponse)
+    );
   };
 
   public restartServer = (): void => {
     console.log('restartServer');
   };
-
-  private getTopics = (): Observable<any> =>
-    this.http.get(`${api.url}/${api.routes.GET}`);
-
-  private postEnv = (): Observable<any> =>
-    this.http.post(`${api.url}/${api.routes.POST}`, this.env);
 
   private handleMessages = (messages: any[] = []): void => {
     this.messages = processMessages(messages);

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,26 +1,34 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnDestroy, OnInit {
   public title = 'node-azure-servicebus-explorer-fe';
   public messages = null;
 
+  private subscriptions = new Subscription();
   private apiUrl = 'http://localhost:3000';
 
   constructor(private http: HttpClient) {}
 
   public ngOnInit(): void {
-    this.getTopics().subscribe((msgs) => {
-      this.messages = msgs;
-    });
+    this.subscriptions.add(this.getTopics().subscribe(this.handleMessages));
+  }
+
+  public ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 
   private getTopics() {
     return this.http.get(this.apiUrl + '/peek');
   }
+
+  private handleMessages = (msgs: any[] = []): void => {
+    this.messages = msgs;
+  };
 }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -2,6 +2,8 @@ import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { processMessages } from './functions';
+import { api } from './structs';
+import { emptyPostRequestBody } from './structs/mocks';
 
 @Component({
   selector: 'app-root',
@@ -10,13 +12,10 @@ import { processMessages } from './functions';
 })
 export class AppComponent implements OnDestroy, OnInit {
   public title = 'node-azure-servicebus-explorer-fe';
-  public connectionString = '';
-  public topicName = '';
-  public subscriptionName = '';
+  public env = emptyPostRequestBody;
   public messages: string[] = [];
 
   private subscriptions = new Subscription();
-  private apiUrl = 'http://localhost:3000';
 
   constructor(private http: HttpClient) {}
 
@@ -29,7 +28,7 @@ export class AppComponent implements OnDestroy, OnInit {
   }
 
   public updateConnection = (): void => {
-    this.postEnv().subscribe((res) => console.log('res', res));
+    this.subscriptions.add(this.postEnv().subscribe(this.handlePostResponse));
   };
 
   public restartServer = (): void => {
@@ -37,19 +36,16 @@ export class AppComponent implements OnDestroy, OnInit {
   };
 
   private getTopics = (): Observable<any> =>
-    this.http.get(`${this.apiUrl}/peek`);
+    this.http.get(`${api.url}/${api.routes.GET}`);
 
-  private postEnv = (): Observable<any> => {
-    const {
-      connectionString: connString,
-      topicName: topic,
-      subscriptionName: sub,
-    } = this;
-    const body: any = { connString, topic, sub };
-    return this.http.post(`${this.apiUrl}/set-env`, body);
-  };
+  private postEnv = (): Observable<any> =>
+    this.http.post(`${api.url}/${api.routes.POST}`, this.env);
 
   private handleMessages = (messages: any[] = []): void => {
     this.messages = processMessages(messages);
+  };
+
+  private handlePostResponse = (res: any): void => {
+    console.log('POST response', res);
   };
 }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,12 +1,13 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule, HttpClientModule],
+  imports: [AppRoutingModule, BrowserModule, FormsModule, HttpClientModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/frontend/src/app/functions/api/apiConfig.ts
+++ b/frontend/src/app/functions/api/apiConfig.ts
@@ -1,0 +1,6 @@
+import { HttpClient } from '@angular/common/http';
+
+export interface ApiConfig {
+  http: HttpClient;
+  url: string;
+}

--- a/frontend/src/app/functions/api/apiRoutes.ts
+++ b/frontend/src/app/functions/api/apiRoutes.ts
@@ -1,0 +1,5 @@
+export enum ApiRoutes {
+  peek = 'peek',
+  setEnv = 'set-env',
+  kill = 'kill',
+}

--- a/frontend/src/app/functions/api/getApi.ts
+++ b/frontend/src/app/functions/api/getApi.ts
@@ -1,26 +1,11 @@
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { flatMap } from 'rxjs/operators';
 import { API, PostRequestBody } from '../../structs';
+import { getTopics } from './getTopics';
+import { postEnv } from './postEnv';
 
 const defaultUrl = 'http://localhost:3000';
 
-enum ApiRoutes {
-  peek = 'peek',
-  setEnv = 'set-env',
-  kill = 'kill',
-}
-
 export const getApi = (http: HttpClient, url = defaultUrl): API => ({
-  getTopics: (): Observable<any> => http.get(`${url}/${ApiRoutes.peek}`),
-
-  postEnv: (env: PostRequestBody): Observable<any> =>
-    http
-      .post(`${url}/${ApiRoutes.setEnv}`, env)
-      .pipe(
-        flatMap(
-          (response: any): Observable<any> =>
-            http.post(`${url}/${ApiRoutes.kill}`, null)
-        )
-      ),
+  getTopics: () => getTopics({ http, url }),
+  postEnv: (env: PostRequestBody) => postEnv({ http, url, env }),
 });

--- a/frontend/src/app/functions/api/getApi.ts
+++ b/frontend/src/app/functions/api/getApi.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
-import { API, PostRequestBody } from '../structs';
+import { API, PostRequestBody } from '../../structs';
 
 const defaultUrl = 'http://localhost:3000';
 

--- a/frontend/src/app/functions/api/getTopics.ts
+++ b/frontend/src/app/functions/api/getTopics.ts
@@ -1,11 +1,6 @@
-import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiConfig } from './apiConfig';
 import { ApiRoutes } from './apiRoutes';
 
-export const getTopics = ({
-  http,
-  url,
-}: {
-  http: HttpClient;
-  url: string;
-}): Observable<any> => http.get(`${url}/${ApiRoutes.peek}`);
+export const getTopics = ({ http, url }: ApiConfig): Observable<any> =>
+  http.get(`${url}/${ApiRoutes.peek}`);

--- a/frontend/src/app/functions/api/getTopics.ts
+++ b/frontend/src/app/functions/api/getTopics.ts
@@ -1,13 +1,20 @@
 import { Observable, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { catchError, mergeMap, retryWhen } from 'rxjs/operators';
 import { ApiConfig } from './apiConfig';
 import { ApiRoutes } from './apiRoutes';
 import { noteError } from './noteError';
+import { retryWithLimitAndDelay } from './retryWithLimitAndDelay';
+
+const retryGet = (error: any, index: number): Observable<any> =>
+  retryWithLimitAndDelay({ error, index, action: 'GET' });
+
+const handleError = (error: any): Observable<any> => {
+  noteError('load messages', error);
+  return of([]);
+};
 
 export const getTopics = ({ http, url }: ApiConfig): Observable<any> =>
   http.get(`${url}/${ApiRoutes.peek}`).pipe(
-    catchError((error: any) => {
-      noteError('load messages', error);
-      return of([]);
-    })
+    retryWhen((errors) => errors.pipe(mergeMap(retryGet))),
+    catchError(handleError)
   );

--- a/frontend/src/app/functions/api/getTopics.ts
+++ b/frontend/src/app/functions/api/getTopics.ts
@@ -1,6 +1,13 @@
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { ApiConfig } from './apiConfig';
 import { ApiRoutes } from './apiRoutes';
+import { noteError } from './noteError';
 
 export const getTopics = ({ http, url }: ApiConfig): Observable<any> =>
-  http.get(`${url}/${ApiRoutes.peek}`);
+  http.get(`${url}/${ApiRoutes.peek}`).pipe(
+    catchError((error: any) => {
+      noteError('load messages', error);
+      return of([]);
+    })
+  );

--- a/frontend/src/app/functions/api/getTopics.ts
+++ b/frontend/src/app/functions/api/getTopics.ts
@@ -1,0 +1,11 @@
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ApiRoutes } from './apiRoutes';
+
+export const getTopics = ({
+  http,
+  url,
+}: {
+  http: HttpClient;
+  url: string;
+}): Observable<any> => http.get(`${url}/${ApiRoutes.peek}`);

--- a/frontend/src/app/functions/api/index.ts
+++ b/frontend/src/app/functions/api/index.ts
@@ -1,0 +1,1 @@
+export { getApi } from './getApi';

--- a/frontend/src/app/functions/api/killServer.ts
+++ b/frontend/src/app/functions/api/killServer.ts
@@ -1,0 +1,11 @@
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ApiRoutes } from './apiRoutes';
+
+export const killServer = ({
+  http,
+  url,
+}: {
+  http: HttpClient;
+  url: string;
+}): Observable<any> => http.post(`${url}/${ApiRoutes.kill}`, null);

--- a/frontend/src/app/functions/api/killServer.ts
+++ b/frontend/src/app/functions/api/killServer.ts
@@ -4,10 +4,10 @@ import { ApiConfig } from './apiConfig';
 import { ApiRoutes } from './apiRoutes';
 import { noteError } from './noteError';
 
+const handleError = (error: any): Observable<any> => {
+  noteError('restart server', error);
+  return of();
+};
+
 export const killServer = ({ http, url }: ApiConfig): Observable<any> =>
-  http.post(`${url}/${ApiRoutes.kill}`, null).pipe(
-    catchError((error: any) => {
-      noteError('restart server', error);
-      return of();
-    })
-  );
+  http.post(`${url}/${ApiRoutes.kill}`, null).pipe(catchError(handleError));

--- a/frontend/src/app/functions/api/killServer.ts
+++ b/frontend/src/app/functions/api/killServer.ts
@@ -1,11 +1,6 @@
-import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { ApiConfig } from './apiConfig';
 import { ApiRoutes } from './apiRoutes';
 
-export const killServer = ({
-  http,
-  url,
-}: {
-  http: HttpClient;
-  url: string;
-}): Observable<any> => http.post(`${url}/${ApiRoutes.kill}`, null);
+export const killServer = ({ http, url }: ApiConfig): Observable<any> =>
+  http.post(`${url}/${ApiRoutes.kill}`, null);

--- a/frontend/src/app/functions/api/killServer.ts
+++ b/frontend/src/app/functions/api/killServer.ts
@@ -1,6 +1,13 @@
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { ApiConfig } from './apiConfig';
 import { ApiRoutes } from './apiRoutes';
+import { noteError } from './noteError';
 
 export const killServer = ({ http, url }: ApiConfig): Observable<any> =>
-  http.post(`${url}/${ApiRoutes.kill}`, null);
+  http.post(`${url}/${ApiRoutes.kill}`, null).pipe(
+    catchError((error: any) => {
+      noteError('restart server', error);
+      return of();
+    })
+  );

--- a/frontend/src/app/functions/api/noteError.ts
+++ b/frontend/src/app/functions/api/noteError.ts
@@ -1,0 +1,7 @@
+export const noteError = (action = '', error: any): void => {
+  console.log(`Error for action "${action}":`, error);
+  const message =
+    `Something went wrong. Could not ${action}.\n\n` +
+    `Please try again, or check the console for more information.`;
+  alert(message);
+};

--- a/frontend/src/app/functions/api/postEnv.ts
+++ b/frontend/src/app/functions/api/postEnv.ts
@@ -1,15 +1,20 @@
-import { Observable } from 'rxjs';
-import { flatMap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, flatMap } from 'rxjs/operators';
 import { PostRequestBody } from '../../structs';
 import { ApiConfig } from './apiConfig';
 import { ApiRoutes } from './apiRoutes';
 import { killServer } from './killServer';
+import { noteError } from './noteError';
 
 interface PostConfig extends ApiConfig {
   env: PostRequestBody;
 }
 
 export const postEnv = ({ http, url, env }: PostConfig): Observable<any> =>
-  http
-    .post(`${url}/${ApiRoutes.setEnv}`, env)
-    .pipe(flatMap((response: any) => killServer({ http, url })));
+  http.post(`${url}/${ApiRoutes.setEnv}`, env).pipe(
+    catchError((error: any) => {
+      noteError('update environment', error);
+      return of();
+    }),
+    flatMap((response: any) => killServer({ http, url }))
+  );

--- a/frontend/src/app/functions/api/postEnv.ts
+++ b/frontend/src/app/functions/api/postEnv.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
 import { PostRequestBody } from '../../structs';
 import { ApiRoutes } from './apiRoutes';
+import { killServer } from './killServer';
 
 export const postEnv = ({
   http,
@@ -15,9 +16,4 @@ export const postEnv = ({
 }): Observable<any> =>
   http
     .post(`${url}/${ApiRoutes.setEnv}`, env)
-    .pipe(
-      flatMap(
-        (response: any): Observable<any> =>
-          http.post(`${url}/${ApiRoutes.kill}`, null)
-      )
-    );
+    .pipe(flatMap((response: any) => killServer({ http, url })));

--- a/frontend/src/app/functions/api/postEnv.ts
+++ b/frontend/src/app/functions/api/postEnv.ts
@@ -1,0 +1,23 @@
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { flatMap } from 'rxjs/operators';
+import { PostRequestBody } from '../../structs';
+import { ApiRoutes } from './apiRoutes';
+
+export const postEnv = ({
+  http,
+  url,
+  env,
+}: {
+  http: HttpClient;
+  url: string;
+  env: PostRequestBody;
+}): Observable<any> =>
+  http
+    .post(`${url}/${ApiRoutes.setEnv}`, env)
+    .pipe(
+      flatMap(
+        (response: any): Observable<any> =>
+          http.post(`${url}/${ApiRoutes.kill}`, null)
+      )
+    );

--- a/frontend/src/app/functions/api/postEnv.ts
+++ b/frontend/src/app/functions/api/postEnv.ts
@@ -10,11 +10,13 @@ interface PostConfig extends ApiConfig {
   env: PostRequestBody;
 }
 
+const handleError = (error: any): Observable<any> => {
+  noteError('update environment', error);
+  return of();
+};
+
 export const postEnv = ({ http, url, env }: PostConfig): Observable<any> =>
   http.post(`${url}/${ApiRoutes.setEnv}`, env).pipe(
-    catchError((error: any) => {
-      noteError('update environment', error);
-      return of();
-    }),
+    catchError(handleError),
     flatMap((response: any) => killServer({ http, url }))
   );

--- a/frontend/src/app/functions/api/postEnv.ts
+++ b/frontend/src/app/functions/api/postEnv.ts
@@ -1,19 +1,15 @@
-import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
 import { PostRequestBody } from '../../structs';
+import { ApiConfig } from './apiConfig';
 import { ApiRoutes } from './apiRoutes';
 import { killServer } from './killServer';
 
-export const postEnv = ({
-  http,
-  url,
-  env,
-}: {
-  http: HttpClient;
-  url: string;
+interface PostConfig extends ApiConfig {
   env: PostRequestBody;
-}): Observable<any> =>
+}
+
+export const postEnv = ({ http, url, env }: PostConfig): Observable<any> =>
   http
     .post(`${url}/${ApiRoutes.setEnv}`, env)
     .pipe(flatMap((response: any) => killServer({ http, url })));

--- a/frontend/src/app/functions/api/retryWithLimitAndDelay.ts
+++ b/frontend/src/app/functions/api/retryWithLimitAndDelay.ts
@@ -19,9 +19,9 @@ export const retryWithLimitAndDelay = ({
   action?: string;
 }): Observable<any> => {
   const numRetry = index + 1;
-  if (numRetry <= numRetries) {
-    console.log(`${action} failed. Retry`, numRetry, 'of', numRetries);
-    return of(error).pipe(delay(msDelay));
+  if (numRetry > numRetries) {
+    return throwError(error);
   }
-  return throwError(error);
+  console.log(`${action} failed. Retry`, numRetry, 'of', numRetries);
+  return of(error).pipe(delay(msDelay));
 };

--- a/frontend/src/app/functions/api/retryWithLimitAndDelay.ts
+++ b/frontend/src/app/functions/api/retryWithLimitAndDelay.ts
@@ -1,0 +1,27 @@
+import { Observable, of, throwError } from 'rxjs';
+import { delay } from 'rxjs/operators';
+
+const defaultNumRetries = 4;
+const defaultMsDelay = 500;
+const defaultAction = 'Operation';
+
+export const retryWithLimitAndDelay = ({
+  error,
+  index,
+  numRetries = defaultNumRetries,
+  msDelay = defaultMsDelay,
+  action = defaultAction,
+}: {
+  error: any;
+  index: number;
+  numRetries?: number;
+  msDelay?: number;
+  action?: string;
+}): Observable<any> => {
+  const numRetry = index + 1;
+  if (numRetry <= numRetries) {
+    console.log(`${action} failed. Retry`, numRetry, 'of', numRetries);
+    return of(error).pipe(delay(msDelay));
+  }
+  return throwError(error);
+};

--- a/frontend/src/app/functions/getApi.ts
+++ b/frontend/src/app/functions/getApi.ts
@@ -1,0 +1,17 @@
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API, PostRequestBody } from '../structs';
+
+const defaultUrl = 'http://localhost:3000';
+
+enum ApiRoutes {
+  GET = 'peek',
+  POST = 'set-env',
+}
+
+export const getApi = (http: HttpClient, url = defaultUrl): API => ({
+  getTopics: (): Observable<any> => http.get(`${url}/${ApiRoutes.GET}`),
+
+  postEnv: (env: PostRequestBody): Observable<any> =>
+    http.post(`${url}/${ApiRoutes.POST}`, env),
+});

--- a/frontend/src/app/functions/getApi.ts
+++ b/frontend/src/app/functions/getApi.ts
@@ -1,17 +1,26 @@
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { flatMap } from 'rxjs/operators';
 import { API, PostRequestBody } from '../structs';
 
 const defaultUrl = 'http://localhost:3000';
 
 enum ApiRoutes {
-  GET = 'peek',
-  POST = 'set-env',
+  peek = 'peek',
+  setEnv = 'set-env',
+  kill = 'kill',
 }
 
 export const getApi = (http: HttpClient, url = defaultUrl): API => ({
-  getTopics: (): Observable<any> => http.get(`${url}/${ApiRoutes.GET}`),
+  getTopics: (): Observable<any> => http.get(`${url}/${ApiRoutes.peek}`),
 
   postEnv: (env: PostRequestBody): Observable<any> =>
-    http.post(`${url}/${ApiRoutes.POST}`, env),
+    http
+      .post(`${url}/${ApiRoutes.setEnv}`, env)
+      .pipe(
+        flatMap(
+          (response: any): Observable<any> =>
+            http.post(`${url}/${ApiRoutes.kill}`, null)
+        )
+      ),
 });

--- a/frontend/src/app/functions/index.ts
+++ b/frontend/src/app/functions/index.ts
@@ -1,1 +1,2 @@
+export { getApi } from './getApi';
 export { processMessages } from './processMessages';

--- a/frontend/src/app/functions/index.ts
+++ b/frontend/src/app/functions/index.ts
@@ -1,0 +1,1 @@
+export { processMessages } from './processMessages';

--- a/frontend/src/app/functions/index.ts
+++ b/frontend/src/app/functions/index.ts
@@ -1,2 +1,2 @@
-export { getApi } from './getApi';
+export { getApi } from './api';
 export { processMessages } from './processMessages';

--- a/frontend/src/app/functions/index.ts
+++ b/frontend/src/app/functions/index.ts
@@ -1,2 +1,3 @@
 export { getApi } from './api';
+export { isEnvValid } from './isEnvValid';
 export { processMessages } from './processMessages';

--- a/frontend/src/app/functions/isEnvValid.ts
+++ b/frontend/src/app/functions/isEnvValid.ts
@@ -1,0 +1,4 @@
+import { PostRequestBody } from '../structs';
+
+export const isEnvValid = (env: PostRequestBody): boolean =>
+  Object.values(env).every(Boolean);

--- a/frontend/src/app/functions/processMessages.ts
+++ b/frontend/src/app/functions/processMessages.ts
@@ -1,2 +1,2 @@
-export const processMessages = (msgs: any[] = []): string[] =>
-  msgs?.flatMap((x: any): string => x?.[0]?.body ?? []) ?? [];
+export const processMessages = (messages: any[] = []): string[] =>
+  messages?.flatMap((x: any): string => x?.[0]?.body ?? []) ?? [];

--- a/frontend/src/app/functions/processMessages.ts
+++ b/frontend/src/app/functions/processMessages.ts
@@ -1,0 +1,2 @@
+export const processMessages = (msgs: any[] = []): string[] =>
+  msgs?.flatMap((x: any): string => x?.[0]?.body ?? []) ?? [];

--- a/frontend/src/app/functions/processMessages.ts
+++ b/frontend/src/app/functions/processMessages.ts
@@ -1,2 +1,11 @@
+const processMessage = (x: any): any => {
+  const body: any = x?.[0]?.body ?? null;
+  return body === null
+    ? []
+    : typeof body === 'string'
+    ? body
+    : JSON.stringify(body);
+};
+
 export const processMessages = (messages: any[] = []): string[] =>
-  messages?.flatMap((x: any): string => x?.[0]?.body ?? []) ?? [];
+  messages?.flatMap(processMessage) ?? [];

--- a/frontend/src/app/structs/api.ts
+++ b/frontend/src/app/structs/api.ts
@@ -1,8 +1,22 @@
-const url = 'http://localhost:3000';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { PostRequestBody } from './postRequestBody';
+
+const defaultUrl = 'http://localhost:3000';
 
 enum ApiRoutes {
   GET = 'peek',
   POST = 'set-env',
 }
 
-export const api = { url, routes: ApiRoutes };
+export interface API {
+  getTopics: () => Observable<any>;
+  postEnv: (env: PostRequestBody) => Observable<any>;
+}
+
+export const getApi = (http: HttpClient, url = defaultUrl): API => ({
+  getTopics: (): Observable<any> => http.get(`${url}/${ApiRoutes.GET}`),
+
+  postEnv: (env: PostRequestBody): Observable<any> =>
+    http.post(`${url}/${ApiRoutes.POST}`, env),
+});

--- a/frontend/src/app/structs/api.ts
+++ b/frontend/src/app/structs/api.ts
@@ -1,0 +1,8 @@
+const url = 'http://localhost:3000';
+
+enum ApiRoutes {
+  GET = 'peek',
+  POST = 'set-env',
+}
+
+export const api = { url, routes: ApiRoutes };

--- a/frontend/src/app/structs/api.ts
+++ b/frontend/src/app/structs/api.ts
@@ -1,22 +1,7 @@
-import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { PostRequestBody } from './postRequestBody';
-
-const defaultUrl = 'http://localhost:3000';
-
-enum ApiRoutes {
-  GET = 'peek',
-  POST = 'set-env',
-}
 
 export interface API {
   getTopics: () => Observable<any>;
   postEnv: (env: PostRequestBody) => Observable<any>;
 }
-
-export const getApi = (http: HttpClient, url = defaultUrl): API => ({
-  getTopics: (): Observable<any> => http.get(`${url}/${ApiRoutes.GET}`),
-
-  postEnv: (env: PostRequestBody): Observable<any> =>
-    http.post(`${url}/${ApiRoutes.POST}`, env),
-});

--- a/frontend/src/app/structs/index.ts
+++ b/frontend/src/app/structs/index.ts
@@ -1,2 +1,2 @@
-export { API, getApi } from './api';
+export { API } from './api';
 export { PostRequestBody } from './postRequestBody';

--- a/frontend/src/app/structs/index.ts
+++ b/frontend/src/app/structs/index.ts
@@ -1,2 +1,2 @@
-export { api } from './api';
+export { API, getApi } from './api';
 export { PostRequestBody } from './postRequestBody';

--- a/frontend/src/app/structs/index.ts
+++ b/frontend/src/app/structs/index.ts
@@ -1,0 +1,2 @@
+export { api } from './api';
+export { PostRequestBody } from './postRequestBody';

--- a/frontend/src/app/structs/mocks/emptyPostRequestBody.ts
+++ b/frontend/src/app/structs/mocks/emptyPostRequestBody.ts
@@ -1,0 +1,7 @@
+import { PostRequestBody } from '../postRequestBody';
+
+export const emptyPostRequestBody: PostRequestBody = {
+  connString: '',
+  topic: '',
+  sub: '',
+};

--- a/frontend/src/app/structs/mocks/index.ts
+++ b/frontend/src/app/structs/mocks/index.ts
@@ -1,0 +1,1 @@
+export { emptyPostRequestBody } from './emptyPostRequestBody';

--- a/frontend/src/app/structs/postRequestBody.ts
+++ b/frontend/src/app/structs/postRequestBody.ts
@@ -1,0 +1,5 @@
+export interface PostRequestBody {
+  connString: string;
+  topic: string;
+  sub: string;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2015",
-    "lib": ["es2018", "dom"]
+    "lib": ["es2019", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
The "update connection" button now submits the entered data, then kills the server (causing it to restart), then re-queries for messages. You can switch connections as many times as you want within the same session.

Some other highlights of this PR:
* Required to fill in all inputs before submission
* Error handling on all API calls
* Message query retries on failure, after a delay, a limited number of times (this enables the automatic message refresh after switching connections).